### PR TITLE
feat: HLTMu20_prescale

### DIFF
--- a/config.py
+++ b/config.py
@@ -78,6 +78,31 @@ def build_config(
                     "2018": "data/golden_json/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt",
                 }
             ),
+                        "PU_reweighting_file_HLTMu20": EraModifier(
+                {
+                    "2016preVFP": "data/PU_HLTMu20/2016preVFP_UL/puWeights.json.gz",
+                    "2016postVFP": "data/PU_HLTMu20/2016postVFP_UL/puWeights.json.gz",
+                    "2017": "data/PU_HLTMu20/2017_UL/puWeights.json.gz",
+                    "2018": "data/PU_HLTMu20/2018_UL/puWeights.json.gz",
+                }
+            ),
+            "PU_reweighting_era_HLTMu20": EraModifier(
+                {
+                    "2016preVFP": "Collisions16_UltraLegacy_goldenJSON",
+                    "2016postVFP": "Collisions16_UltraLegacy_goldenJSON",
+                    "2017": "Collisions17_UltraLegacy_goldenJSON",
+                    "2018": "Collisions18_UltraLegacy_goldenJSON",
+                }
+            ),
+            "PU_reweighting_variation_HLTMu20": "nominal",
+            "golden_json_file": EraModifier(
+                {
+                    "2016preVFP": "data/golden_json/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt",
+                    "2016postVFP": "data/golden_json/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt",
+                    "2017": "data/golden_json/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt",
+                    "2018": "data/golden_json/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt",
+                }
+            ),
             "met_filters": EraModifier(
                 {
                     "2016preVFP": [
@@ -712,6 +737,9 @@ def build_config(
                 event.PUweights,
                 event.PUweights_up,
                 event.PUweights_down,
+                event.PUweights_HLTMu20,
+                event.PUweights_HLTMu20_up,
+                event.PUweights_HLTMu20_down,
                 jets.JetEnergyCorrection,
             ],
         )
@@ -1012,6 +1040,9 @@ def build_config(
                 q.puweight,
                 q.puweight_up,
                 q.puweight_down,
+                q.puweight_HLTMu20,
+                q.puweight_HLTMu20_up,
+                q.puweight_HLTMu20_down,
 
                 q.lep_sf_mu_trigger_nom, q.lep_sf_mu_trigger_up, q.lep_sf_mu_trigger_down,
                 q.lep_sf_mu_iso_nom, q.lep_sf_mu_iso_up, q.lep_sf_mu_iso_down,

--- a/producers/event.py
+++ b/producers/event.py
@@ -187,6 +187,30 @@ PUweights_down = Producer(
     scopes=["global"],
 )
 
+PUweights_HLTMu20 = Producer(
+    name="PUweights_HLTMu20",
+    call='reweighting::puweights({df}, {output}, {input}, "{PU_reweighting_file_HLTMu20}", "{PU_reweighting_era_HLTMu20}", "nominal")',
+    input=[nanoAOD.Pileup_nTrueInt],
+    output=[q.puweight_HLTMu20],
+    scopes=["global"],
+)
+
+PUweights_HLTMu20_up = Producer(
+    name="PUweights_HLTMu20_up",
+    call='reweighting::puweights({df}, {output}, {input}, "{PU_reweighting_file_HLTMu20}", "{PU_reweighting_era_HLTMu20}", "up")',
+    input=[nanoAOD.Pileup_nTrueInt],
+    output=[q.puweight_HLTMu20_up],
+    scopes=["global"],
+)
+
+PUweights_HLTMu20_down = Producer(
+    name="PUweights_HLTMu20_down",
+    call='reweighting::puweights({df}, {output}, {input}, "{PU_reweighting_file_HLTMu20}", "{PU_reweighting_era_HLTMu20}", "down")',
+    input=[nanoAOD.Pileup_nTrueInt],
+    output=[q.puweight_HLTMu20_down],
+    scopes=["global"],
+)
+
 
 PUweightsFromHistogram = Producer(
     name="PUweightsFromHistogram",

--- a/quantities/nanoAOD.py
+++ b/quantities/nanoAOD.py
@@ -175,3 +175,7 @@ HLT_Mu27 = NanoAODQuantity("HLT_Mu27")
 ## PV
 
 PV_npvs = NanoAODQuantity("PV_npvs")
+
+## PU
+
+Pileup_nTrueInt = NanoAODQuantity("Pileup_nTrueInt")

--- a/quantities/output.py
+++ b/quantities/output.py
@@ -329,6 +329,9 @@ LHEPdfWeight = Quantity("LHEPdfWeight_vector")
 puweight = Quantity("puweight")
 puweight_up = Quantity("puweight_up")
 puweight_down = Quantity("puweight_down")
+puweight_HLTMu20 = Quantity("puweight_HLTMu20")
+puweight_HLTMu20_up = Quantity("puweight_HLTMu20_up")
+puweight_HLTMu20_down = Quantity("puweight_HLTMu20_down")
 
 
 


### PR DESCRIPTION
-  adding updated PU profiles/weights for prescaled HLTMu20 trigger (needed for QCD estimation
-  store number of true number of pileup interactions (needed for comparison plot with vs. without PU weights)

Note: updated PU profiles for HLTMu20 trigger are currently privately stored in my version of CROWN (folder `data/PU_HLTMu20`), to be pushed into my fork