### PR TITLE
[feat] added QCD shifts based on rel. iso.

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ from .producers import raw_branches as raw_branches
 from .quantities import nanoAOD as nanoAOD
 from .quantities import output as q
 from .jet_variations import add_jetVariations
+from .qcdiso_variations import add_qcdisoVariations
 from .btag_variations import add_btagVariations
 from .jec_data import add_jetCorrectionData
 from code_generation.configuration import Configuration
@@ -1137,6 +1138,11 @@ def build_config(
     # Jet energy resolution and jet energy scale
     #########################
     add_jetVariations(configuration, available_sample_types, era)
+
+    #########################
+    # QCD shape variations
+    #########################
+    add_qcdisoVariations(configuration, available_sample_types, era)
 
     #########################
     # systs related to leptons

--- a/qcdiso_variations.py
+++ b/qcdiso_variations.py
@@ -1,0 +1,61 @@
+from __future__ import annotations  # needed for type annotations in > python 3.7
+
+from typing import List
+from code_generation.configuration import Configuration
+from code_generation.systematics import SystematicShift
+from .producers import electrons as electrons
+from .producers import muons as muons
+
+
+def add_qcdisoVariations(
+    configuration: Configuration, available_sample_types: List[str], era: str
+):
+    #########################
+    # nonprompt lepton isolation
+    # up: Irel > 0.25
+    # down: Irel > 0.15
+    # nom: Irel > 0.2 
+    #########################
+    configuration.add_shift(
+        SystematicShift(
+            name="QCDIsoMuUncUp",
+            shift_config={
+                "lep": {"mu_antiiso": 0.25},
+            },
+            producers={"lep": [muons.LooseMuons, muons.NumberOfLooseMuons, muons.TightMuons, muons.NumberOfTightMuons, muons.AntiTightMuons, muons.NumberOfAntiTightMuons]},
+        ),
+       samples=["data"]
+    )
+    configuration.add_shift(
+        SystematicShift(
+            name="QCDIsoElUncUp",
+            shift_config={
+                "lep": {"el_antiiso": 0.25},
+            },
+            producers={"lep": [electrons.LooseElectrons, electrons.NumberOfLooseElectrons, electrons.TightElectrons, electrons.NumberOfTightElectrons, electrons.AntiTightElectrons, electrons.NumberOfAntiTightElectrons]},
+        ),
+        samples=["data"]
+    )
+    configuration.add_shift(
+        SystematicShift(
+            name="QCDIsoMuUncDown",
+            shift_config={
+                "lep": {"mu_antiiso": 0.15, "loose_mu_iso": 0.15},
+            },
+            producers={"lep": [muons.LooseMuons, muons.NumberOfLooseMuons, muons.TightMuons, muons.NumberOfTightMuons, muons.AntiTightMuons, muons.NumberOfAntiTightMuons]},
+        ),
+        samples=["data"]
+    )
+    configuration.add_shift(
+        SystematicShift(
+            name="QCDIsoElUncDown",
+            shift_config={
+                "lep": {"el_antiiso": 0.15},
+            },
+            producers={"lep": [electrons.LooseElectrons, electrons.NumberOfLooseElectrons, electrons.TightElectrons, electrons.NumberOfTightElectrons, electrons.AntiTightElectrons, electrons.NumberOfAntiTightElectrons]},
+        ),
+        samples=["data"]
+    )
+
+
+    return configuration


### PR DESCRIPTION
Added variations for `I_rel > 0.25 (up)` and `I_rel > 0.15 (down)` for defining uncertainty on the data-driven QCD estimation in the noniso sideband, where the nominal value is `I_rel > 0.2`.

Note: for down variation in muon channel, loose muon iso had to be adjusted to `I_rel < 0.15`